### PR TITLE
Add toggle shortcut for firefox (and chrome)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,5 +24,12 @@
     "48": "icon/icon48.png",
     "96": "icon/icon96.png",
     "128": "icon/icon128.png"
+  },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "linux": "Ctrl+Shift+L"
+      }
+    }  
   }
 }


### PR DESCRIPTION
This update adds a shortcut to trigger the extension on and off, as [talked here](https://github.com/begeeben/find-your-tab/issues/1).
Works both in chrome and firefox (at least on linux).

